### PR TITLE
 #64 Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -17,7 +17,6 @@ class AssignsController < ApplicationController
   def destroy
     assign = Assign.find(params[:id])
     destroy_message = assign_destroy(assign, assign.user)
-
     redirect_to team_url(params[:team_id]), notice: destroy_message
   end
 
@@ -31,9 +30,13 @@ class AssignsController < ApplicationController
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')
-    elsif assign.destroy
-      set_next_team(assign, assigned_user)
-      I18n.t('views.messages.delete_member')
+    # 追加 issue1 'チームのリーダーか、ユーザー自身でない場合、削除できません。'
+    elsif current_user != assign.team.owner && current_user != assign.user
+      I18n.t('views.messages.cannot_delete_member_99_some_reason')
+    # redirect_to team_url(params[:team_id])
+    # elsif assign.destroy
+    # set_next_team(assign, assigned_user)
+    # I18n.t('views.messages.delete_member')
     else
       I18n.t('views.messages.cannot_delete_member_4_some_reason')
     end

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -14,6 +14,13 @@ class AssignsController < ApplicationController
     end
   end
 
+  def edit
+  end
+
+  def update
+  end
+
+
   def destroy
     assign = Assign.find(params[:id])
     destroy_message = assign_destroy(assign, assign.user)

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -6,4 +6,7 @@ class AssignMailer < ApplicationMailer
     @password = password
     mail to: @email, subject: I18n.t('views.messages.complete_registration')
   end
+
+  def update_mail(email, name)
+  end  
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -216,6 +216,7 @@ ja:
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
       delete_member: 'メンバーを削除しました。'
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
+      cannot_delete_member_99_some_reason: 'チームのリーダーか、ユーザー自身でない場合、削除できません。'
       failed_to_post: '投稿できませんでした...'
       create_team: 'チーム作成に成功しました！'
       failed_to_save_team: '保存に失敗しました、、'


### PR DESCRIPTION
#64
①Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
②TeamのeditはTeamのリーダー（オーナー）のみができるようにすること